### PR TITLE
Fix NR agent labels - remove colon from repository URL

### DIFF
--- a/newrelic/newrelic-account1.yml
+++ b/newrelic/newrelic-account1.yml
@@ -1,11 +1,11 @@
 common: &default_settings
-  license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY_2"] %>'
+  license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY_1"] %>'
   app_name: UserMappingService
   log_level: info
   audit_mode: false
 
   labels:
-    repository: https://github.com/newrelic-copilot/UserMappingService
+    repository: github.com/newrelic-copilot/UserMappingService
     team: security_rx
     environment: production
 

--- a/newrelic/newrelic-account2.yml
+++ b/newrelic/newrelic-account2.yml
@@ -5,7 +5,7 @@ common: &default_settings
   audit_mode: false
 
   labels:
-    repository: https://github.com/newrelic-copilot/UserMappingService
+    repository: github.com/newrelic-copilot/UserMappingService
     team: security_rx
     environment: production
 


### PR DESCRIPTION
Fixes illegal `:` character in NR labels by changing `https://github.com/...` to `github.com/...`